### PR TITLE
Fix initialization and usage of reader-writer lock in `jess_run` parallel code

### DIFF
--- a/enzymm/jess_run.py
+++ b/enzymm/jess_run.py
@@ -573,7 +573,7 @@ def load_molecules(
 @dataclass
 class QueryMolecule:
     molecule: pyjess.Molecule
-    lock: rwlock.Lockable = rwlock.RWLockRead().gen_rlock()
+    lock: rwlock.Lockable = field(default_factory=rwlock.RWLockRead)
     # the lock is similar to: threading.Lock = threading.Lock()
     hit_found: bool = False
     hit_size: int = 0
@@ -962,7 +962,7 @@ class Matcher:
             template_size = batch_partial.keywords["templates"][0].effective_size
 
             if self.skip_smaller_hits:
-                with molecule.lock:
+                with molecule.lock.gen_rlock():
                     if molecule.hit_found and molecule.hit_size > template_size:
                         progress.advance(task_id=task)
                         return []
@@ -971,7 +971,7 @@ class Matcher:
             results = list(batch_partial(molecule=molecule.molecule))
 
             if results and self.skip_smaller_hits:
-                with molecule.lock:
+                with molecule.lock.gen_wlock():
                     molecule.hit_found = True
                     molecule.hit_size = template_size
 


### PR DESCRIPTION
This PR fixes two errors in `v0.1.7` with regards to lock initialization and acquisition:

- The lock field of the `QueryMolecule` dataclass needs to be initialized with a factory: each molecule can have its own lock, whereas with the current setup all molecules will share the same lock, potentially causing threads to block across molecules when it should have been fine to access them.
- Using `gen_rlock` means that you have a reader lock only, so in the second `with` block where you're gonna write data that's incorrect (actually, your code behaves like you do no locking at all). You should use `gen_rlock` to have a reader lock in the read-only part, and `gen_wlock` to get a writer lock for the writer part.